### PR TITLE
Add shebang to vncserver-start and stop

### DIFF
--- a/APT/LXDE/vncserver-start
+++ b/APT/LXDE/vncserver-start
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export USER=root
 export HOME=/root
 

--- a/APT/LXDE/vncserver-stop
+++ b/APT/LXDE/vncserver-stop
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export USER=root
 export HOME=/root
 

--- a/APT/LXQT/vncserver-start
+++ b/APT/LXQT/vncserver-start
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export USER=root
 export HOME=/root
 

--- a/APT/LXQT/vncserver-stop
+++ b/APT/LXQT/vncserver-stop
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export USER=root
 export HOME=/root
 

--- a/APT/MATE/vncserver-start
+++ b/APT/MATE/vncserver-start
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export USER=root
 export HOME=/root
 

--- a/APT/MATE/vncserver-stop
+++ b/APT/MATE/vncserver-stop
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export USER=root
 export HOME=/root
 

--- a/APT/XFCE4/vncserver-start
+++ b/APT/XFCE4/vncserver-start
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export USER=root
 export HOME=/root
 

--- a/APT/XFCE4/vncserver-stop
+++ b/APT/XFCE4/vncserver-stop
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 export USER=root
 export HOME=/root
 


### PR DESCRIPTION
I am using the fish-shell, and `export VAR=VALUE` is not valid syntax in fish. I added the bash shebang for these scripts to make them run in bash and not in fish.