### PR TITLE
Add correct parameter handling for start-ubuntu.sh

### DIFF
--- a/Installer/Ubuntu/ubuntu.sh
+++ b/Installer/Ubuntu/ubuntu.sh
@@ -71,6 +71,7 @@ else
         command+=" -c $@"
 fi
 exec \$command
+EOM
 
 echo "fixing shebang of $bin"
 termux-fix-shebang $bin

--- a/Installer/Ubuntu/ubuntu.sh
+++ b/Installer/Ubuntu/ubuntu.sh
@@ -64,14 +64,13 @@ command+=" HOME=/root"
 command+=" PATH=/usr/local/sbin:/usr/local/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/games:/usr/local/games"
 command+=" TERM=\$TERM"
 command+=" LANG=C.UTF-8"
-command+=" /bin/bash --login"
-com="\$@"
-if [ -z "\$1" ];then
-    exec \$command
+command+=" /bin/bash"
+if [[ -z \$1 ]];then
+        command+=" --login"
 else
-    \$command -c "\$com"
+        command+=" -c $@"
 fi
-EOM
+exec \$command
 
 echo "fixing shebang of $bin"
 termux-fix-shebang $bin


### PR DESCRIPTION
The existing version does not actually accept parameters to run commands in the container without having to login first, even though it should.  EG `./start-ubuntu.sh "whoami"` should output `root`.  
The current fix will allow these commands to actually work. It should be changed across all of the install scripts for the modded OS especially, which I do not have access to.