### PR TITLE
Permanent command alias for Ubuntu22 and Ubuntu20

### DIFF
--- a/Installer/Ubuntu20/ubuntu20.sh
+++ b/Installer/Ubuntu20/ubuntu20.sh
@@ -250,6 +250,27 @@ chmod +x $bin
 echo "removing image for some space"
 rm $tarball
 clear
-echo "You can now launch Ubuntu with the ./${bin} script from next time"
+
+### Set-up an alias to allow easy execution from any dir
+
+# Path to bashrc on termux
+bashrc="/data/data/com.termux/files/usr/etc/bash.bashrc"
+
+# Get the absolute path of $bin i.e start-ubuntu20.sh
+Ubuntu=$(readlink -f ./${bin})
+
+# Check if the bashrc file exists
+if [ -f ${bashrc} ]; 
+	then
+		# Add alias to the bashrc file
+		echo "alias ubuntu20=${Ubuntu}" >> ${bashrc}
+		# Reload bashrc
+		source $bashrc
+		echo "Next time, Launch Ubuntu with this command: ubuntu20"
+else 
+	# Use previous statement if no bashrc
+	echo "You can now launch Ubuntu with the ./${bin} script from next time"
+fi	
+# echo "You can now launch Ubuntu with the ./${bin} script from next time"
 bash $bin
 

--- a/Installer/Ubuntu22/ubuntu22.sh
+++ b/Installer/Ubuntu22/ubuntu22.sh
@@ -243,9 +243,9 @@ Ubuntu=$(readlink -f ./${bin})
 if [ -f ${bashrc} ]; 
 	then
 		# Add alias to the bashrc file
-		echo "alias ubuntu=${Ubuntu}" >> ${bashrc}
+		echo "alias ubuntu22=${Ubuntu}" >> ${bashrc}
 		source $bashrc
-		echo "Next time, Launch Ubuntu with this command: ubuntu"
+		echo "Next time, Launch Ubuntu with this command: ubuntu22"
 else 
 	echo "You can now launch Ubuntu with the ./${bin} script from next time"
 fi	

--- a/Installer/Ubuntu22/ubuntu22.sh
+++ b/Installer/Ubuntu22/ubuntu22.sh
@@ -244,6 +244,7 @@ if [ -f ${bashrc} ];
 	then
 		# Add alias to the bashrc file
 		echo "alias ubuntu22=${Ubuntu}" >> ${bashrc}
+		# Reload bashrc
 		source $bashrc
 		echo "Next time, Launch Ubuntu with this command: ubuntu22"
 else 

--- a/Installer/Ubuntu22/ubuntu22.sh
+++ b/Installer/Ubuntu22/ubuntu22.sh
@@ -229,6 +229,25 @@ chmod +x $bin
 echo "removing image for some space"
 rm $tarball
 clear
-echo "You can now launch Ubuntu with the ./${bin} script from next time"
+
+
+### Set-up an alias to allow easy execution from any dir
+
+# Path to bashrc on termux
+bashrc="/data/data/com.termux/files/usr/etc/bash.bashrc"
+
+# Get the absolute path of $bin
+Ubuntu=$(readlink -f ./${bin})
+
+# Check if the bashrc file exists
+if [ -f ${bashrc} ]; 
+	then
+		# Add alias to the bashrc file
+		echo "alias ubuntu=${Ubuntu}" >> ${bashrc}
+		source $bashrc
+		echo "Next time, Launch Ubuntu with this command: ubuntu"
+else 
+	echo "You can now launch Ubuntu with the ./${bin} script from next time"
+fi	
 bash $bin
 


### PR DESCRIPTION
I noticed that it's stressful to try running ubuntu if i am not in the home dir where the start-ubuntu22.sh script is. So i found a way to create an alias for the script, like this:

> `alias ubuntu22='./start-ubuntu22.sh'`

then i can use ubuntu22 as a command to run the script. 

But this solution is not fixed i.e can't use it in a new instance of termux. To make it permanent, I added the line above to the bashrc file.
Now I can use ubuntu22 as a command to run Ubuntu from any dir, anytime I open termux.